### PR TITLE
Fix typo and fmt of div example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Let's say, you have the following function:
 
 ```go
 func div(n, d float64) float64 {
-  if in == 0 {
+  if d == 0 {
     panic("denominator must not be zero")
   }
-  return n /d
+  return n / d
 }
 ```
 


### PR DESCRIPTION
- Fix parameter name in `div` func example (probably a typo)
- go-fmt the `div` example