### PR TITLE
fix possible nil panic, load packages faster

### DIFF
--- a/contracts/analyzer.go
+++ b/contracts/analyzer.go
@@ -70,6 +70,11 @@ func analyzeImports(facts Result, pass *analysis.Pass) {
 			pkg, err := loadPackageInfo(importPath)
 			if err != nil {
 				pass.Reportf(nImport.Pos(), "load package info: %v", err)
+				continue
+			}
+			if pkg.TypesInfo == nil {
+				pass.Reportf(nImport.Pos(), "package loaded without NeedTypesInfo flag")
+				continue
 			}
 			exportFacts(facts, pkg.TypesInfo, pkg.Syntax)
 		}
@@ -77,11 +82,7 @@ func analyzeImports(facts Result, pass *analysis.Pass) {
 }
 
 func loadPackageInfo(pkgName string) (*packages.Package, error) {
-	loadMode := (packages.NeedName |
-		packages.NeedSyntax |
-		packages.NeedDeps |
-		packages.NeedTypes |
-		packages.NeedTypesInfo)
+	loadMode := packages.NeedName | packages.NeedTypes | packages.NeedTypesInfo
 	cfg := &packages.Config{Mode: loadMode}
 	pkgs, err := packages.Load(cfg, string(pkgName))
 	if err != nil {


### PR DESCRIPTION
1. Fix a possible panic detected by [nilaway](https://github.com/uber-go/nilaway)
2. Use fewer flags when loading packages in contracts to do it faster.